### PR TITLE
Adds new features and some fixes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ module.exports = postcss.plugin('postcss-remify', function (opts) {
             }
 
             var index = decl.value.indexOf('(');
-            var last = decl.value.indexOf(')');
             var last  = decl.value.indexOf(')');
             var value = decl.value.slice(++index, last);
             value     = value.match(/\d+/)[0];

--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ module.exports = postcss.plugin('postcss-remify', function (opts) {
             var value = decl.value.slice(++index, last);
             value     = value.match(/\d+/)[0];
 
+            if (opts.fallback) {
+              decl.cloneBefore({
+                prop  : 'font-size',
+                value : value + 'px'
+              });
+            }
+
             decl.value = value / base + 'rem';
         });
     };

--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ module.exports = postcss.plugin('postcss-remify', function (opts) {
 
             var index = decl.value.indexOf('(');
             var last = decl.value.indexOf(')');
+            var last  = decl.value.indexOf(')');
             var value = decl.value.slice(++index, last);
+            value     = value.match(/\d+/)[0];
 
             decl.value = value / base + 'rem';
         });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,15 @@
 var postcss = require('postcss');
 
 module.exports = postcss.plugin('postcss-remify', function (opts) {
-    opts = opts || {};
+    opts = opts || { base : 16, fallback : false };
+
+    if (typeof opts.base === 'undefined') {
+      opts.base = 16;
+    }
+
+    if (typeof opts.fallback === 'undefined') {
+      opts.fallback = false;
+    }
 
     return function (css) {
         css.walkDecls( function (decl) {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = postcss.plugin('postcss-remify', function (opts) {
 
     return function (css) {
         css.walkDecls( function (decl) {
-            var base = 16;
+            var base = opts.base;
 
             if (!decl.value || decl.value.indexOf('rem(') === -1) {
                 return;


### PR DESCRIPTION
#### Fixes
Checks for trash text inside parenthesis for the first number found, so in: 
```
font-size : rem( lorem50ipsum ); 
```
the value 50 will be catched.

#### New Features
Adds new fallback and base options to the plugin.

- fallback : bool = If set to true, it will add "font-size : Npx" before the rem declaration. (Default : False)
- base : int = The value provided in the declaration will be divided by this number. (Default : 16)